### PR TITLE
Include context variables.

### DIFF
--- a/src/BreakpointExtension.php
+++ b/src/BreakpointExtension.php
@@ -24,14 +24,17 @@ class BreakpointExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('breakpoint', array($this, 'setBreakpoint')),
+            new \Twig_SimpleFunction('breakpoint', array($this, 'setBreakpoint'), array('needs_environment' => true, 'needs_context' => true)),
         );
     }
 
     /**
      * If XDebug is detected, makes the debugger break.
+     *
+     * @param mixed $environment the environment instance
+     * @param mixed $context     variables from the Twig template
      */
-    public function setBreakpoint()
+    public function setBreakpoint($environment, $context)
     {
         if (function_exists('xdebug_break')) {
             xdebug_break();


### PR DESCRIPTION
While the breakpoint works, none of the variables from the Twig template are available to inspect. Setting 'needs_context' to true will pass the variables to setBreakpoint(), which in turn needs to accept the variables as an argument so they appear through xdebug.
