### PR TITLE
Allow to inspect function arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Add `$environment` and `$context` variables
+- Allow to inspect function arguments
 
 ## [0.2.0] - 2016-03-10
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ Once registered, you can call the new `breakpoint` function:
 
 Once stopped, your debugger will allow you to inspect the `$environment` and `$context` variables.
 
+### Function arguments
+
+Any argument passed to the twig function will be added to the `$arguments` array, so you can inspect it easily.
+
+```twig
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>title</title>
+  </head>
+  <body>
+    {{ breakpoint(app.user, app.session) }}
+  </body>
+</html>
+```
 
 Symfony Bundle
 --------------

--- a/src/BreakpointExtension.php
+++ b/src/BreakpointExtension.php
@@ -40,6 +40,7 @@ class BreakpointExtension extends Twig_Extension
     public function setBreakpoint(Twig_Environment $environment, $context)
     {
         if (function_exists('xdebug_break')) {
+            $arguments = array_slice(func_get_args(), 2);
             xdebug_break();
         }
     }


### PR DESCRIPTION
Any argument passed to the twig function will be added to the `$arguments`
array, so you can inspect it easily.
